### PR TITLE
add timestamp on create/update profile

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -10,7 +10,7 @@ exports.register = function (server, options, next) {
       description: 'save JSON object',
       auth: false,
       handler: function (request, reply) {
-
+        request.payload.date = Date.now();
         if(request.payload.url) {
 
             es.search({
@@ -35,7 +35,6 @@ exports.register = function (server, options, next) {
 
                       //keep the list of favourite if the profile is updated from the api
                       request.payload.favourite = response.hits.hits[0]._source.favourite;
-
                       es.index({
                         index: process.env.ES_INDEX,
                         type: process.env.ES_TYPE,
@@ -53,7 +52,6 @@ exports.register = function (server, options, next) {
                       return reply("401");
                     }
                 } else {
-
                     es.index({
                       index: process.env.ES_INDEX,
                       type: process.env.ES_TYPE,

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,4 +1,5 @@
 require('env2')('.env');
+var es = require('../lib/es.js');
 var Code = require('code');
 var Lab = require('lab');
 var Server = require('../lib/index.js');
@@ -214,7 +215,7 @@ describe('api /profile', function () {
 
     });
   });
-
+  var idTom;
   it("Create tom's profile which doesn't have a url", function (done) {
 
     Server.init(0, function (err, server) {
@@ -231,11 +232,24 @@ describe('api /profile', function () {
 
       server.inject(options, function (res) {
         expect(res.statusCode).to.equal(200);
+        idTom = res.payload;
         server.stop(done);
       });
 
     });
   });
+
+  it("Check that tom has a timestamp", function (done) {
+    es.get({
+      index: process.env.ES_INDEX,
+      type: process.env.ES_TYPE,
+      id: idTom
+    }, function (error, response) {
+      expect(parseInt(response._source.date, 10)).to.be.above(1449506430320);
+      done();
+    });
+  });
+
 
     it('create profile Maria', function (done) {
 


### PR DESCRIPTION
Add a timestamp when we create or update a profile, see [issue 154](https://github.com/FAC-GM/app/issues/154)
@nelsonic Do you mind to have a look at the code? Thanks