### PR TITLE
changed the env to the right type 

### DIFF
--- a/lib/database-helpers/elasticsearch/update_jobs_client.js
+++ b/lib/database-helpers/elasticsearch/update_jobs_client.js
@@ -16,7 +16,7 @@ module.exports = function (idClient, idJob, next) {
 
     clientES.update({
       index: process.env.ES_INDEX,
-      type: process.env.ES_TYPE_CLIENTS_COMPANIES,
+      type: process.env.ES_TYPE_GM_CLIENTS,
       id: idClient,
       body: {doc: {jobs: Array.from(jobs)}}
     }, function(errUpdate, responseUpdate) {


### PR DESCRIPTION
We couldn't save the job on the client type because we were using wrong env variable

Related to #429 

This is a small PR @nelsonic do you have a moment to check this one? thanks 